### PR TITLE
Add `InMemory` transport and integration tests

### DIFF
--- a/.idea/.idea.Coderynx.MessagingKit/.idea/indexLayout.xml
+++ b/.idea/.idea.Coderynx.MessagingKit/.idea/indexLayout.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="UserContentModel">
+    <attachedFolders />
+    <explicitIncludes />
+    <explicitExcludes />
+  </component>
+</project>

--- a/Coderynx.MessagingKit.sln
+++ b/Coderynx.MessagingKit.sln
@@ -13,6 +13,14 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Coderynx.MessagingKit", "sr
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Coderynx.MessagingKit.Transports.RabbitMq", "src\Coderynx.MessagingKit.Transports.RabbitMq\Coderynx.MessagingKit.Transports.RabbitMq.csproj", "{8DCF19B0-9DA4-4A96-8247-75CC4DB96ED6}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Coderynx.MessagingKit.Transports.InMemory", "src\Coderynx.MessagingKit.Transports.InMemory\Coderynx.MessagingKit.Transports.InMemory.csproj", "{B7E3B3D1-2E1A-4C9C-9C1F-5D0A6B50B7E5}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Coderynx.MessagingKit.Transports.RabbitMq.IntegrationTests", "tests\Coderynx.MessagingKit.Transports.RabbitMq.IntegrationTests\Coderynx.MessagingKit.Transports.RabbitMq.IntegrationTests.csproj", "{A1B2C3D4-E5F6-4721-ABCD-1234567890AB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Coderynx.MessagingKit.Transports.InMemory.IntegrationTests", "tests\Coderynx.MessagingKit.Transports.InMemory.IntegrationTests\Coderynx.MessagingKit.Transports.InMemory.IntegrationTests.csproj", "{9DEF743B-6FB2-4672-86B0-05171E69D2C8}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Coderynx.MessagingKit.Tests.Shared", "tests\Coderynx.MessagingKit.Tests.Shared\Coderynx.MessagingKit.Tests.Shared.csproj", "{826AC55B-933A-47C1-B2F6-A19484D62D8B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -25,6 +33,10 @@ Global
 		{0F8D560E-52B5-4306-81F5-376D7F2C76A4} = {632DE579-8063-47DC-8B02-E1DCE7F4451A}
 		{F5218C31-672E-4BA4-9ED1-0C6665E4DC6D} = {632DE579-8063-47DC-8B02-E1DCE7F4451A}
 		{8DCF19B0-9DA4-4A96-8247-75CC4DB96ED6} = {632DE579-8063-47DC-8B02-E1DCE7F4451A}
+		{B7E3B3D1-2E1A-4C9C-9C1F-5D0A6B50B7E5} = {632DE579-8063-47DC-8B02-E1DCE7F4451A}
+		{A1B2C3D4-E5F6-4721-ABCD-1234567890AB} = {1C7EE5A8-5499-44AC-9D9F-C9A04D6016D1}
+		{9DEF743B-6FB2-4672-86B0-05171E69D2C8} = {1C7EE5A8-5499-44AC-9D9F-C9A04D6016D1}
+		{826AC55B-933A-47C1-B2F6-A19484D62D8B} = {1C7EE5A8-5499-44AC-9D9F-C9A04D6016D1}
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{0F8D560E-52B5-4306-81F5-376D7F2C76A4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -39,5 +51,21 @@ Global
 		{8DCF19B0-9DA4-4A96-8247-75CC4DB96ED6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8DCF19B0-9DA4-4A96-8247-75CC4DB96ED6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8DCF19B0-9DA4-4A96-8247-75CC4DB96ED6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B7E3B3D1-2E1A-4C9C-9C1F-5D0A6B50B7E5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B7E3B3D1-2E1A-4C9C-9C1F-5D0A6B50B7E5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B7E3B3D1-2E1A-4C9C-9C1F-5D0A6B50B7E5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B7E3B3D1-2E1A-4C9C-9C1F-5D0A6B50B7E5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A1B2C3D4-E5F6-4721-ABCD-1234567890AB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A1B2C3D4-E5F6-4721-ABCD-1234567890AB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A1B2C3D4-E5F6-4721-ABCD-1234567890AB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A1B2C3D4-E5F6-4721-ABCD-1234567890AB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9DEF743B-6FB2-4672-86B0-05171E69D2C8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9DEF743B-6FB2-4672-86B0-05171E69D2C8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9DEF743B-6FB2-4672-86B0-05171E69D2C8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9DEF743B-6FB2-4672-86B0-05171E69D2C8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{826AC55B-933A-47C1-B2F6-A19484D62D8B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{826AC55B-933A-47C1-B2F6-A19484D62D8B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{826AC55B-933A-47C1-B2F6-A19484D62D8B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{826AC55B-933A-47C1-B2F6-A19484D62D8B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# Coderynx.MessagingKit
+
+This repository contains the core messaging abstractions and transports (RabbitMQ, InMemory) for Coderynx.MessagingKit.

--- a/src/Coderynx.MessagingKit.Transports.InMemory/Coderynx.MessagingKit.Transports.InMemory.csproj
+++ b/src/Coderynx.MessagingKit.Transports.InMemory/Coderynx.MessagingKit.Transports.InMemory.csproj
@@ -1,13 +1,13 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <PackageId>Coderynx.MessagingKit.Abstractions</PackageId>
+        <PackageId>Coderynx.MessagingKit.Transports.InMemory</PackageId>
         <Authors>coderynx</Authors>
-        <Description>Messaging library abstractions</Description>
-        <PackageTags>messaging</PackageTags>
+        <Description>In-memory transport for Coderynx.MessagingKit</Description>
+        <PackageTags>messaging;inmemory</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <IncludeSymbols>true</IncludeSymbols>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
@@ -16,6 +16,10 @@
 
     <ItemGroup>
         <None Include="..\..\README.md" Pack="true" PackagePath=""/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Coderynx.MessagingKit\Coderynx.MessagingKit.csproj"/>
     </ItemGroup>
 
 </Project>

--- a/src/Coderynx.MessagingKit.Transports.InMemory/InMemoryBuilder.cs
+++ b/src/Coderynx.MessagingKit.Transports.InMemory/InMemoryBuilder.cs
@@ -1,0 +1,29 @@
+using Coderynx.MessagingKit.Abstractions;
+using Coderynx.MessagingKit.Exceptions;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Coderynx.MessagingKit.Transports.InMemory;
+
+public sealed class InMemoryBuilder : BusBuilderBase
+{
+    private string _busName = "default";
+
+    internal InMemoryBuilder(IServiceCollection services) : base(services)
+    {
+    }
+
+    public void WithBusName(string name)
+    {
+        _busName = name;
+    }
+
+    internal InMemoryOptions Build()
+    {
+        if (string.IsNullOrWhiteSpace(_busName))
+        {
+            throw new MessagingKitBusConfigurationException(nameof(_busName));
+        }
+
+        return new InMemoryOptions(_busName, MessageRegistrations);
+    }
+}

--- a/src/Coderynx.MessagingKit.Transports.InMemory/InMemoryMessageBus.cs
+++ b/src/Coderynx.MessagingKit.Transports.InMemory/InMemoryMessageBus.cs
@@ -1,0 +1,141 @@
+using System.Threading.Channels;
+using Coderynx.MessagingKit.Abstractions;
+using Microsoft.Extensions.Logging;
+
+namespace Coderynx.MessagingKit.Transports.InMemory;
+
+internal sealed class InMemoryMessageBus(
+    ILogger<InMemoryMessageBus> logger,
+    MessageDispatcher dispatcher,
+    MessageBusOptionsBase options) : IMessageBus
+{
+    private readonly Dictionary<string, Channel<Letter>> _channels = new(StringComparer.OrdinalIgnoreCase);
+    private readonly CancellationTokenSource _cts = new();
+    private readonly Dictionary<Type, string> _typeToTopic = new();
+    private readonly List<Task> _workers = [];
+
+    public bool IsInitialized => !_cts.IsCancellationRequested;
+
+    public Task InitializeAsync(CancellationToken cancellationToken = default)
+    {
+        logger.LogInformation("Initialized InMemory bus {BusName}", options.BusName);
+
+        var registrations = options.MessageRegistrations
+            .Where(registration => registration.ConsumerType is not null)
+            .ToArray();
+
+        foreach (var registration in registrations)
+        {
+            var topic = registration.GetTopicName();
+            _typeToTopic[registration.MessageType] = topic;
+
+            var channel = Channel.CreateUnbounded<Letter>(new UnboundedChannelOptions
+            {
+                SingleReader = false,
+                SingleWriter = false,
+                AllowSynchronousContinuations = true
+            });
+
+            _channels[topic] = channel;
+
+            var worker = Task.Run(() => WorkerAsync(topic, channel.Reader, _cts.Token), cancellationToken);
+            _workers.Add(worker);
+
+            logger.LogInformation("Listening for messages on topic {Topic}", topic);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public async Task PublishAsync(Letter letter, CancellationToken cancellationToken = default)
+    {
+        if (!_typeToTopic.TryGetValue(letter.PayloadType, out var topic))
+        {
+            topic = string.Concat(letter.PayloadType.Name
+                .Select((x, i) => i > 0 && char.IsUpper(x) ? "-" + char.ToLower(x) : char.ToLower(x).ToString()));
+        }
+
+        logger.LogTrace("InMemory publish to topic {Topic}", topic);
+
+        if (!_channels.TryGetValue(topic, out var channel))
+        {
+            logger.LogWarning("No in-memory consumer channel found for topic {Topic}. Message will not be delivered.",
+                topic);
+            return;
+        }
+
+        await channel.Writer.WriteAsync(letter, cancellationToken);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        logger.LogInformation("Terminating InMemory bus {BusName}", options.BusName);
+
+        try
+        {
+            await _cts.CancelAsync();
+        }
+        catch
+        {
+            // ignore
+        }
+
+        foreach (var channel in _channels.Values)
+        {
+            try
+            {
+                channel.Writer.TryComplete();
+            }
+            catch
+            {
+                /* ignore */
+            }
+        }
+
+        try
+        {
+            await Task.WhenAll(_workers);
+        }
+        catch (Exception ex)
+        {
+            logger.LogDebug(ex, "Error while awaiting in-memory workers shutdown");
+        }
+
+        _cts.Dispose();
+
+        logger.LogInformation("Terminated InMemory bus {BusName}", options.BusName);
+    }
+
+    private async Task WorkerAsync(string topic, ChannelReader<Letter> reader, CancellationToken cancellationToken)
+    {
+        try
+        {
+            while (await reader.WaitToReadAsync(cancellationToken))
+            {
+                while (reader.TryRead(out var letter))
+                {
+                    try
+                    {
+                        await dispatcher.DispatchAsync(letter, cancellationToken);
+                    }
+                    catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                    {
+                        return;
+                    }
+                    catch (Exception ex)
+                    {
+                        logger.LogError(ex, "Failed to dispatch in-memory message on topic {Topic}", topic);
+                    }
+                }
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // graceful shutdown
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Unhandled error in in-memory worker for topic {Topic}", topic);
+        }
+    }
+}

--- a/src/Coderynx.MessagingKit.Transports.InMemory/InMemoryOptions.cs
+++ b/src/Coderynx.MessagingKit.Transports.InMemory/InMemoryOptions.cs
@@ -1,0 +1,8 @@
+using Coderynx.MessagingKit.Abstractions;
+
+namespace Coderynx.MessagingKit.Transports.InMemory;
+
+public sealed record InMemoryOptions(
+    string BusName,
+    HashSet<MessageRegistration> MessageRegistrations)
+    : MessageBusOptionsBase(typeof(InMemoryMessageBus), BusName, MessageRegistrations);

--- a/src/Coderynx.MessagingKit.Transports.InMemory/MessagingBuilderExtensions.cs
+++ b/src/Coderynx.MessagingKit.Transports.InMemory/MessagingBuilderExtensions.cs
@@ -1,0 +1,24 @@
+using Coderynx.MessagingKit.Abstractions;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Coderynx.MessagingKit.Transports.InMemory;
+
+public static class MessagingBuilderExtensions
+{
+    public static void AddInMemory(this MessagingBuilder builder, Action<InMemoryBuilder> configure)
+    {
+        var inMemoryBuilder = new InMemoryBuilder(builder.Services);
+        configure(inMemoryBuilder);
+
+        var options = inMemoryBuilder.Build();
+        builder.Services.Configure<MessagingOptions>(messagingOptions => messagingOptions.BusOptions.Add(options));
+
+        builder.Services.AddSingleton<IMessageBus>(sp =>
+        {
+            var busProvider = sp.GetRequiredService<MessageBusManager>();
+
+            return busProvider.ResolveBus(options.BusName) ??
+                   throw new ApplicationException($"Message bus '{options.BusName}' not found");
+        });
+    }
+}

--- a/src/Coderynx.MessagingKit.Transports.RabbitMq/Coderynx.MessagingKit.Transports.RabbitMq.csproj
+++ b/src/Coderynx.MessagingKit.Transports.RabbitMq/Coderynx.MessagingKit.Transports.RabbitMq.csproj
@@ -25,9 +25,6 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.9"/>
         <PackageReference Include="RabbitMQ.Client" Version="7.1.2"/>
-        <PackageReference Update="Nerdbank.GitVersioning">
-            <Version>3.8.118</Version>
-        </PackageReference>
     </ItemGroup>
 
 </Project>

--- a/src/Coderynx.MessagingKit.Transports.RabbitMq/RabbitMqBuilder.cs
+++ b/src/Coderynx.MessagingKit.Transports.RabbitMq/RabbitMqBuilder.cs
@@ -1,4 +1,5 @@
 using Coderynx.MessagingKit.Abstractions;
+using Coderynx.MessagingKit.Exceptions;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Coderynx.MessagingKit.Transports.RabbitMq;
@@ -32,7 +33,7 @@ public sealed class RabbitMqBuilder : BusBuilderBase
     {
         if (_uri is null)
         {
-            throw new ApplicationException("RabbitMQ connection string not configured");
+            throw new MessagingKitBusConfigurationException(nameof(_uri));
         }
 
         return new RabbitMqOptions(_busName, _uri, _clientName, MessageRegistrations);

--- a/src/Coderynx.MessagingKit/Abstractions/IMessageBus.cs
+++ b/src/Coderynx.MessagingKit/Abstractions/IMessageBus.cs
@@ -7,6 +7,16 @@ namespace Coderynx.MessagingKit.Abstractions;
 public interface IMessageBus : IAsyncDisposable
 {
     /// <summary>
+    ///     Indicates whether the message bus has been successfully initialized.
+    /// </summary>
+    /// <remarks>
+    ///     This property returns true if the InitializeAsync method has been executed
+    ///     and the required setup for the message bus has been completed; otherwise, it returns false.
+    ///     It is used to determine the readiness of the message bus for operations such as publishing messages.
+    /// </remarks>
+    bool IsInitialized { get; }
+
+    /// <summary>
     ///     Asynchronously initializes the message bus, setting up necessary connections, channels,
     ///     exchanges, and queues for message handling.
     /// </summary>

--- a/src/Coderynx.MessagingKit/Coderynx.MessagingKit.csproj
+++ b/src/Coderynx.MessagingKit/Coderynx.MessagingKit.csproj
@@ -22,9 +22,6 @@
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.9"/>
         <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.9"/>
         <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.9"/>
-        <PackageReference Update="Nerdbank.GitVersioning">
-            <Version>3.8.118</Version>
-        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Coderynx.MessagingKit/Exceptions/MessagingKitBusConfigurationException.cs
+++ b/src/Coderynx.MessagingKit/Exceptions/MessagingKitBusConfigurationException.cs
@@ -1,0 +1,7 @@
+namespace Coderynx.MessagingKit.Exceptions;
+
+public sealed class MessagingKitBusConfigurationException(string parameterName) :
+    Exception($"Configuration parameter '{parameterName}' is invalid or missing.")
+{
+    public string ParameterName { get; } = parameterName;
+}

--- a/src/Coderynx.MessagingKit/HostConfiguration.cs
+++ b/src/Coderynx.MessagingKit/HostConfiguration.cs
@@ -5,9 +5,14 @@ namespace Coderynx.MessagingKit;
 
 public static class HostConfiguration
 {
-    public static void UseMessaging(this IHost host)
+    public static void UseMessaging(this IHost host, bool waitForInitialization = false)
     {
         var busProvider = host.Services.GetRequiredService<MessageBusManager>();
         busProvider.InitializeBuses();
+
+        if (waitForInitialization)
+        {
+            busProvider.WaitForBusesInitialization();
+        }
     }
 }

--- a/tests/Coderynx.MessagingKit.Tests.Shared/Class1.cs
+++ b/tests/Coderynx.MessagingKit.Tests.Shared/Class1.cs
@@ -1,0 +1,5 @@
+﻿namespace Coderynx.MessagingKit.Tests.Shared;
+
+public class Class1
+{
+}

--- a/tests/Coderynx.MessagingKit.Tests.Shared/Coderynx.MessagingKit.Tests.Shared.csproj
+++ b/tests/Coderynx.MessagingKit.Tests.Shared/Coderynx.MessagingKit.Tests.Shared.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net9.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\Coderynx.MessagingKit\Coderynx.MessagingKit.csproj"/>
+    </ItemGroup>
+
+</Project>

--- a/tests/Coderynx.MessagingKit.Tests.Shared/Consumers/SampleMessageConsumer.cs
+++ b/tests/Coderynx.MessagingKit.Tests.Shared/Consumers/SampleMessageConsumer.cs
@@ -1,0 +1,15 @@
+using Coderynx.MessagingKit.Abstractions;
+using Coderynx.MessagingKit.Tests.Shared.TestSupport;
+
+namespace Coderynx.MessagingKit.Tests.Shared.Consumers;
+
+public sealed record SampleMessage(string Text);
+
+public sealed class SampleMessageConsumer(TestProbe probe) : IConsumer<SampleMessage>
+{
+    public Task ConsumeAsync(ConsumerContext<SampleMessage> context, CancellationToken ct = default)
+    {
+        probe.Record(context.Message);
+        return Task.CompletedTask;
+    }
+}

--- a/tests/Coderynx.MessagingKit.Tests.Shared/TestSupport/TestProbe.cs
+++ b/tests/Coderynx.MessagingKit.Tests.Shared/TestSupport/TestProbe.cs
@@ -1,0 +1,15 @@
+using System.Collections.Concurrent;
+
+namespace Coderynx.MessagingKit.Tests.Shared.TestSupport;
+
+public sealed class TestProbe
+{
+    private readonly ConcurrentBag<object> _messages = [];
+
+    public IReadOnlyCollection<object> Messages => _messages.ToArray();
+
+    public void Record(object message)
+    {
+        _messages.Add(message);
+    }
+}

--- a/tests/Coderynx.MessagingKit.Tests.Shared/TestSupport/WaitHelper.cs
+++ b/tests/Coderynx.MessagingKit.Tests.Shared/TestSupport/WaitHelper.cs
@@ -1,0 +1,18 @@
+namespace Coderynx.MessagingKit.Tests.Shared.TestSupport;
+
+public static class WaitHelper
+{
+    public static async Task<bool> WaitUntilAsync(Func<bool> condition, TimeSpan timeout, TimeSpan? pollInterval = null)
+    {
+        var start = DateTime.UtcNow;
+        var interval = pollInterval ?? TimeSpan.FromMilliseconds(50);
+
+        while (DateTime.UtcNow - start < timeout)
+        {
+            if (condition()) return true;
+            await Task.Delay(interval);
+        }
+
+        return condition();
+    }
+}

--- a/tests/Coderynx.MessagingKit.Transports.InMemory.IntegrationTests/ApplicationFactory.cs
+++ b/tests/Coderynx.MessagingKit.Transports.InMemory.IntegrationTests/ApplicationFactory.cs
@@ -1,0 +1,50 @@
+using Coderynx.MessagingKit.Tests.Shared.Consumers;
+using Coderynx.MessagingKit.Tests.Shared.TestSupport;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+
+namespace Coderynx.MessagingKit.Transports.InMemory.IntegrationTests;
+
+public sealed class ApplicationFactory : WebApplicationFactory<ApplicationFactory>, IAsyncLifetime
+{
+    public Task InitializeAsync()
+    {
+        return Task.CompletedTask;
+    }
+
+    public new Task DisposeAsync()
+    {
+        return Task.CompletedTask;
+    }
+
+    protected override IHost CreateHost(IHostBuilder builder)
+    {
+        var appBuilder = WebApplication.CreateBuilder();
+
+        appBuilder.AddMessaging(messaging =>
+        {
+            messaging.AddInMemory(rabbitMq =>
+            {
+                rabbitMq.WithBusName("test-bus");
+                rabbitMq.WithEvent<SampleMessage>();
+            });
+        });
+
+        appBuilder.Services.AddSingleton<TestProbe>();
+
+        appBuilder.Services.RemoveAll<IHostedService>();
+        appBuilder.WebHost.UseTestServer();
+
+        var app = appBuilder.Build();
+
+        app.UseMessaging(true);
+
+        _ = app.RunAsync();
+
+        return app;
+    }
+}

--- a/tests/Coderynx.MessagingKit.Transports.InMemory.IntegrationTests/BusAvailableTests.cs
+++ b/tests/Coderynx.MessagingKit.Transports.InMemory.IntegrationTests/BusAvailableTests.cs
@@ -1,0 +1,112 @@
+using Coderynx.MessagingKit.Tests.Shared.Consumers;
+using Coderynx.MessagingKit.Tests.Shared.TestSupport;
+using Shouldly;
+
+namespace Coderynx.MessagingKit.Transports.InMemory.IntegrationTests;
+
+public sealed class BusAvailableTests(ApplicationFactory applicationFactory) : IntegrationTestsBase(applicationFactory)
+{
+    [Fact]
+    public async Task ConsumeAsync_ShouldConsumeMessage()
+    {
+        // Arrange
+        var message = new SampleMessage("hello in-memory");
+        await Publisher.PublishAsync(message);
+
+        // Act
+        var received = await WaitHelper.WaitUntilAsync(
+            () => Probe.Messages.OfType<SampleMessage>().Any(m => m.Text.Equals("hello in-memory")),
+            timeout: TimeSpan.FromSeconds(5));
+
+        // Assert
+        received.ShouldBeTrue("Message was not received within the timeout period.");
+    }
+
+    [Fact]
+    public async Task PublishAsync_ShouldPublishMessage()
+    {
+        // Arrange
+        var message = new SampleMessage("hello in-memory");
+
+        // Act & Assert
+        await Should.NotThrowAsync(() => Publisher.PublishAsync(message));
+    }
+
+    [Fact]
+    public async Task ConsumeAsync_ShouldTimeoutWhenNoMessage()
+    {
+        // Arrange
+        var uniqueText = $"no-message-{Guid.NewGuid()}";
+
+        // Act
+        var received = await WaitHelper.WaitUntilAsync(
+            () => Probe.Messages.OfType<SampleMessage>().Any(m => m.Text == uniqueText),
+            timeout: TimeSpan.FromMilliseconds(500));
+
+        // Assert
+        received.ShouldBeFalse("Predicate should remain false when no message is published.");
+    }
+
+    [Fact]
+    public async Task ConsumeAsync_ShouldConsumeMultipleMessages()
+    {
+        // Arrange
+        var baseText = $"batch-{Guid.NewGuid()}";
+        var payloads = Enumerable.Range(1, 5)
+            .Select(i => new SampleMessage($"{baseText}-{i}"))
+            .ToArray();
+
+        foreach (var msg in payloads)
+            await Publisher.PublishAsync(msg);
+
+        // Act
+        var receivedAll = await WaitHelper.WaitUntilAsync(
+            () =>
+                Probe.Messages.OfType<SampleMessage>()
+                    .Select(m => m.Text)
+                    .Where(t => t.StartsWith(baseText + "-", StringComparison.Ordinal))
+                    .Distinct()
+                    .Count() == payloads.Length,
+            timeout: TimeSpan.FromSeconds(10));
+
+        // Assert
+        receivedAll.ShouldBeTrue("Not all batch messages were received within the timeout period.");
+    }
+
+    [Fact]
+    public async Task PublishAsync_ShouldHandleConcurrentPublishes()
+    {
+        // Arrange
+        var texts = Enumerable.Range(1, 10)
+            .Select(_ => $"concurrent-{Guid.NewGuid()}")
+            .ToArray();
+
+        // Act
+        await Task.WhenAll(texts.Select(t => Publisher.PublishAsync(new SampleMessage(t))));
+
+        var receivedAll = await WaitHelper.WaitUntilAsync(
+            () => texts.All(t => Probe.Messages.OfType<SampleMessage>().Any(m => m.Text == t)),
+            timeout: TimeSpan.FromSeconds(10));
+
+        // Assert
+        receivedAll.ShouldBeTrue("Not all concurrently published messages were received.");
+    }
+
+    [Fact]
+    public async Task PublishAsync_ShouldPublishAndConsumeLargeMessage()
+    {
+        // Arrange
+        var largeText = new string('x', 10_000);
+        var message = new SampleMessage(largeText);
+
+        // Act
+        await Should.NotThrowAsync(() => Publisher.PublishAsync(message));
+
+        var received = await WaitHelper.WaitUntilAsync(
+            () => Probe.Messages.OfType<SampleMessage>().Any(m => m.Text.Length == largeText.Length),
+            timeout: TimeSpan.FromSeconds(5));
+
+        // Assert
+        received.ShouldBeTrue("Large message was not received.");
+    }
+}

--- a/tests/Coderynx.MessagingKit.Transports.InMemory.IntegrationTests/Coderynx.MessagingKit.Transports.InMemory.IntegrationTests.csproj
+++ b/tests/Coderynx.MessagingKit.Transports.InMemory.IntegrationTests/Coderynx.MessagingKit.Transports.InMemory.IntegrationTests.csproj
@@ -1,0 +1,29 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net9.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="AutoFixture" Version="4.18.1"/>
+        <PackageReference Include="coverlet.collector" Version="6.0.2"/>
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.9"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0"/>
+        <PackageReference Include="Shouldly" Version="4.3.0"/>
+        <PackageReference Include="xunit" Version="2.9.2"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="Xunit"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\Coderynx.MessagingKit.Transports.InMemory\Coderynx.MessagingKit.Transports.InMemory.csproj"/>
+        <ProjectReference Include="..\Coderynx.MessagingKit.Tests.Shared\Coderynx.MessagingKit.Tests.Shared.csproj"/>
+    </ItemGroup>
+
+</Project>

--- a/tests/Coderynx.MessagingKit.Transports.InMemory.IntegrationTests/IntegrationTestsBase.cs
+++ b/tests/Coderynx.MessagingKit.Transports.InMemory.IntegrationTests/IntegrationTestsBase.cs
@@ -1,0 +1,18 @@
+using AutoFixture;
+using Coderynx.MessagingKit.Abstractions;
+using Coderynx.MessagingKit.Tests.Shared.TestSupport;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Coderynx.MessagingKit.Transports.InMemory.IntegrationTests;
+
+public abstract class IntegrationTestsBase(ApplicationFactory applicationFactory) : IClassFixture<ApplicationFactory>
+{
+    protected readonly IFixture Fixture = new Fixture();
+
+    protected readonly IMessagePublisher Publisher = applicationFactory.Services
+        .CreateScope()
+        .ServiceProvider
+        .GetRequiredService<IMessagePublisher>();
+
+    protected TestProbe Probe => applicationFactory.Services.GetRequiredService<TestProbe>();
+}

--- a/tests/Coderynx.MessagingKit.Transports.RabbitMq.IntegrationTests/ApplicationFactory.cs
+++ b/tests/Coderynx.MessagingKit.Transports.RabbitMq.IntegrationTests/ApplicationFactory.cs
@@ -1,0 +1,71 @@
+using Coderynx.MessagingKit.Tests.Shared.Consumers;
+using Coderynx.MessagingKit.Tests.Shared.TestSupport;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using Testcontainers.RabbitMq;
+
+namespace Coderynx.MessagingKit.Transports.RabbitMq.IntegrationTests;
+
+public sealed class ApplicationFactory : WebApplicationFactory<ApplicationFactory>, IAsyncLifetime
+{
+    private readonly RabbitMqContainer _rabbitMqContainer = new Testcontainers.RabbitMq.RabbitMqBuilder()
+        .Build();
+
+    public async Task InitializeAsync()
+    {
+        await _rabbitMqContainer.StartAsync();
+    }
+
+    public new async Task DisposeAsync()
+    {
+        await _rabbitMqContainer.StopAsync();
+    }
+
+    protected override IHost CreateHost(IHostBuilder builder)
+    {
+        var appBuilder = WebApplication.CreateBuilder();
+
+        appBuilder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["ConnectionStrings:MessageBus"] = _rabbitMqContainer.GetConnectionString()
+        });
+
+        appBuilder.AddMessaging(messaging =>
+        {
+            messaging.AddRabbitMq(rabbitMq =>
+            {
+                var connectionString = appBuilder.Configuration.GetConnectionString("MessageBus");
+                if (string.IsNullOrWhiteSpace(connectionString))
+                {
+                    throw new ApplicationException("MessageBus connection string is not set");
+                }
+
+                var uri = new Uri(connectionString);
+
+                rabbitMq.WithClientName("test-client");
+                rabbitMq.WithBusName("test-bus");
+                rabbitMq.WithUri(uri);
+
+                rabbitMq.WithEvent<SampleMessage>();
+            });
+        });
+
+        appBuilder.Services.AddSingleton<TestProbe>();
+
+        appBuilder.Services.RemoveAll<IHostedService>();
+        appBuilder.WebHost.UseTestServer();
+
+        var app = appBuilder.Build();
+
+        app.UseMessaging(true);
+
+        _ = app.RunAsync();
+
+        return app;
+    }
+}

--- a/tests/Coderynx.MessagingKit.Transports.RabbitMq.IntegrationTests/BusAvailableTests.cs
+++ b/tests/Coderynx.MessagingKit.Transports.RabbitMq.IntegrationTests/BusAvailableTests.cs
@@ -1,0 +1,112 @@
+using Coderynx.MessagingKit.Tests.Shared.Consumers;
+using Coderynx.MessagingKit.Tests.Shared.TestSupport;
+using Shouldly;
+
+namespace Coderynx.MessagingKit.Transports.RabbitMq.IntegrationTests;
+
+public sealed class BusAvailableTests(ApplicationFactory applicationFactory) : IntegrationTestsBase(applicationFactory)
+{
+    [Fact]
+    public async Task ConsumeAsync_ShouldConsumeMessage()
+    {
+        // Arrange
+        var message = new SampleMessage("hello in-memory");
+        await Publisher.PublishAsync(message);
+
+        // Act
+        var received = await WaitHelper.WaitUntilAsync(
+            () => Probe.Messages.OfType<SampleMessage>().Any(m => m.Text.Equals("hello in-memory")),
+            timeout: TimeSpan.FromSeconds(5));
+
+        // Assert
+        received.ShouldBeTrue("Message was not received within the timeout period.");
+    }
+
+    [Fact]
+    public async Task PublishAsync_ShouldPublishMessage()
+    {
+        // Arrange
+        var message = new SampleMessage("hello in-memory");
+
+        // Act & Assert
+        await Should.NotThrowAsync(() => Publisher.PublishAsync(message));
+    }
+
+    [Fact]
+    public async Task ConsumeAsync_ShouldTimeoutWhenNoMessage()
+    {
+        // Arrange
+        var uniqueText = $"no-message-{Guid.NewGuid()}";
+
+        // Act
+        var received = await WaitHelper.WaitUntilAsync(
+            () => Probe.Messages.OfType<SampleMessage>().Any(m => m.Text == uniqueText),
+            timeout: TimeSpan.FromMilliseconds(500));
+
+        // Assert
+        received.ShouldBeFalse("Predicate should remain false when no message is published.");
+    }
+
+    [Fact]
+    public async Task ConsumeAsync_ShouldConsumeMultipleMessages()
+    {
+        // Arrange
+        var baseText = $"batch-{Guid.NewGuid()}";
+        var payloads = Enumerable.Range(1, 5)
+            .Select(i => new SampleMessage($"{baseText}-{i}"))
+            .ToArray();
+
+        foreach (var msg in payloads)
+            await Publisher.PublishAsync(msg);
+
+        // Act
+        var receivedAll = await WaitHelper.WaitUntilAsync(
+            () =>
+                Probe.Messages.OfType<SampleMessage>()
+                    .Select(m => m.Text)
+                    .Where(t => t.StartsWith(baseText + "-", StringComparison.Ordinal))
+                    .Distinct()
+                    .Count() == payloads.Length,
+            timeout: TimeSpan.FromSeconds(10));
+
+        // Assert
+        receivedAll.ShouldBeTrue("Not all batch messages were received within the timeout period.");
+    }
+
+    [Fact]
+    public async Task PublishAsync_ShouldHandleConcurrentPublishes()
+    {
+        // Arrange
+        var texts = Enumerable.Range(1, 10)
+            .Select(_ => $"concurrent-{Guid.NewGuid()}")
+            .ToArray();
+
+        // Act
+        await Task.WhenAll(texts.Select(t => Publisher.PublishAsync(new SampleMessage(t))));
+
+        var receivedAll = await WaitHelper.WaitUntilAsync(
+            () => texts.All(t => Probe.Messages.OfType<SampleMessage>().Any(m => m.Text == t)),
+            timeout: TimeSpan.FromSeconds(10));
+
+        // Assert
+        receivedAll.ShouldBeTrue("Not all concurrently published messages were received.");
+    }
+
+    [Fact]
+    public async Task PublishAsync_ShouldPublishAndConsumeLargeMessage()
+    {
+        // Arrange
+        var largeText = new string('x', 10_000);
+        var message = new SampleMessage(largeText);
+
+        // Act
+        await Should.NotThrowAsync(() => Publisher.PublishAsync(message));
+
+        var received = await WaitHelper.WaitUntilAsync(
+            () => Probe.Messages.OfType<SampleMessage>().Any(m => m.Text.Length == largeText.Length),
+            timeout: TimeSpan.FromSeconds(5));
+
+        // Assert
+        received.ShouldBeTrue("Large message was not received.");
+    }
+}

--- a/tests/Coderynx.MessagingKit.Transports.RabbitMq.IntegrationTests/Coderynx.MessagingKit.Transports.RabbitMq.IntegrationTests.csproj
+++ b/tests/Coderynx.MessagingKit.Transports.RabbitMq.IntegrationTests/Coderynx.MessagingKit.Transports.RabbitMq.IntegrationTests.csproj
@@ -1,0 +1,40 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net9.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="AutoFixture" Version="4.18.1"/>
+        <PackageReference Include="coverlet.collector" Version="6.0.2">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.9"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0"/>
+        <PackageReference Include="Shouldly" Version="4.3.0"/>
+        <PackageReference Include="xunit" Version="2.9.3"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Testcontainers.RabbitMq" Version="4.7.0"/>
+        <PackageReference Update="Nerdbank.GitVersioning">
+            <Version>3.8.118</Version>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="../../src/Coderynx.MessagingKit.Transports.RabbitMq/Coderynx.MessagingKit.Transports.RabbitMq.csproj"/>
+        <ProjectReference Include="..\Coderynx.MessagingKit.Tests.Shared\Coderynx.MessagingKit.Tests.Shared.csproj"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="Xunit"/>
+    </ItemGroup>
+
+</Project>

--- a/tests/Coderynx.MessagingKit.Transports.RabbitMq.IntegrationTests/IntegrationTestsBase.cs
+++ b/tests/Coderynx.MessagingKit.Transports.RabbitMq.IntegrationTests/IntegrationTestsBase.cs
@@ -1,0 +1,18 @@
+using AutoFixture;
+using Coderynx.MessagingKit.Abstractions;
+using Coderynx.MessagingKit.Tests.Shared.TestSupport;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Coderynx.MessagingKit.Transports.RabbitMq.IntegrationTests;
+
+public abstract class IntegrationTestsBase(ApplicationFactory applicationFactory) : IClassFixture<ApplicationFactory>
+{
+    protected readonly IFixture Fixture = new Fixture();
+
+    protected readonly IMessagePublisher Publisher = applicationFactory.Services
+        .CreateScope()
+        .ServiceProvider
+        .GetRequiredService<IMessagePublisher>();
+
+    protected TestProbe Probe => applicationFactory.Services.GetRequiredService<TestProbe>();
+}


### PR DESCRIPTION
This pull request adds support for an in-memory transport to the Coderynx.MessagingKit, introduces a shared integration test infrastructure, improves configuration validation, and makes other minor enhancements. The most notable changes are the implementation of the `InMemory` transport, improvements to bus initialization readiness, and enhanced configuration error handling.

**In-memory transport implementation:**

* Added a new project, `Coderynx.MessagingKit.Transports.InMemory`, with all necessary files (`InMemoryMessageBus`, `InMemoryBuilder`, `InMemoryOptions`, and `MessagingBuilderExtensions`) to provide an in-memory message bus transport. This enables message-based communication without external dependencies for testing or lightweight scenarios. [[1]](diffhunk://#diff-2f2b398aa881e105b6930e1b70d74aa7c30f182240fb7fd704c02abee3916dc4R1-R25) [[2]](diffhunk://#diff-4f8b904b5e5a25e75a08d8bf9a77e65d05fc6f01901fe8c48db06d6974fb0460R1-R29) [[3]](diffhunk://#diff-77637b9a5eab7104b0304c5f8ba9966af9fa1891e8b8bfaff5765731a97229a1R1-R8) [[4]](diffhunk://#diff-a3abefd9c2a4f86cf75a1d413784859aeaff3727f1e5e7a269cb978f5d197559R1-R141) [[5]](diffhunk://#diff-a9e25a8974606a88c0a3fe9a46a01283e672ad36c041fba396c46a5bcb8e48b2R1-R24)
* Updated the solution file (`Coderynx.MessagingKit.sln`) to include the new in-memory transport, its integration tests, and a shared test project. [[1]](diffhunk://#diff-73a9fb053f26a74dd2feeb7b884a71beef9ffaaf621d20ed3eb942a2e08eab3eR16-R23) [[2]](diffhunk://#diff-73a9fb053f26a74dd2feeb7b884a71beef9ffaaf621d20ed3eb942a2e08eab3eR36-R39) [[3]](diffhunk://#diff-73a9fb053f26a74dd2feeb7b884a71beef9ffaaf621d20ed3eb942a2e08eab3eR54-R69)

**Bus initialization and readiness improvements:**

* Added the `IsInitialized` property to the `IMessageBus` interface, and implemented it for both RabbitMQ and in-memory transports, allowing consumers to check if a bus is ready before publishing messages. [[1]](diffhunk://#diff-c1cea7a217a154eb303285b156a017aee59bbef0dac7a263cd38714a26e206d0R9-R18) [[2]](diffhunk://#diff-742e078edfd886751be5327a94031b65426849c9910f9232c09aa79223082560L16-R18)
* Enhanced the `HostConfiguration.UseMessaging` extension method to optionally wait for all message buses to finish initializing before proceeding.

**Configuration and error handling:**

* Introduced a custom exception, `MessagingKitBusConfigurationException`, for clearer configuration error reporting, and updated both RabbitMQ and in-memory builders to use it. [[1]](diffhunk://#diff-0d5c8ac44ccee219beb30440c79f035d1bcfff59b565d669bb2be0f998a8e851R1-R7) [[2]](diffhunk://#diff-5137cc6c640ac193d806085cc450a0e55cf92f02a882701923ca4188faedd899R2) [[3]](diffhunk://#diff-5137cc6c640ac193d806085cc450a0e55cf92f02a882701923ca4188faedd899L35-R36) [[4]](diffhunk://#diff-4f8b904b5e5a25e75a08d8bf9a77e65d05fc6f01901fe8c48db06d6974fb0460R1-R29)

**Other changes:**

* Added a basic `README.md` describing the repository and its transports.
* Removed redundant `Nerdbank.GitVersioning` package references from several project files. [[1]](diffhunk://#diff-86bca5ea3d60c40665ebedc6f54b34664ca7af74db0f0d09830986baac806643L21-L26) [[2]](diffhunk://#diff-965f2f9eb43034870b8b4e4abec85726ed2d4227cd20713cc618d73e73ef5fcbL28-L30) [[3]](diffhunk://#diff-513013283634fbe201257cf4d3dd10deaad5cccd3bae0e1195cf5eef8836920dL25-L27)
* Added a new IDE configuration file for project layout.

These changes collectively provide a more robust, testable, and user-friendly messaging infrastructure.