### PR TITLE
Add `MessagingKit.Abstractions` to `MessagingKit`

### DIFF
--- a/src/Coderynx.MessagingKit.Transports.InMemory/version.json
+++ b/src/Coderynx.MessagingKit.Transports.InMemory/version.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
+  "version": "0.0.1",
+  "publicReleaseRefSpec": [
+    "^refs/heads/main$"
+  ],
+  "cloudBuild": {
+    "buildNumber": {
+      "enabled": true
+    }
+  }
+}

--- a/src/Coderynx.MessagingKit/Coderynx.MessagingKit.csproj
+++ b/src/Coderynx.MessagingKit/Coderynx.MessagingKit.csproj
@@ -19,13 +19,10 @@
     </ItemGroup>
 
     <ItemGroup>
+        <PackageReference Include="Coderynx.MessagingKit.Abstractions" Version="0.0.1" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.9"/>
         <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.9"/>
         <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.9"/>
-    </ItemGroup>
-
-    <ItemGroup>
-        <ProjectReference Include="..\Coderynx.MessagingKit.Abstractions\Coderynx.MessagingKit.Abstractions.csproj"/>
     </ItemGroup>
 
 </Project>

--- a/src/Coderynx.MessagingKit/version.json
+++ b/src/Coderynx.MessagingKit/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "publicReleaseRefSpec": [
     "^refs/heads/main$"
   ],


### PR DESCRIPTION
This pull request introduces versioning improvements to the `Coderynx.MessagingKit` and `Coderynx.MessagingKit.Transports.InMemory` packages, and updates how dependencies are managed in the main project. The most notable changes are the introduction of a version file for the InMemory transport, a version bump for the main package, and a switch from project to package reference for the abstractions dependency.

**Versioning updates:**

* Added a new `version.json` file to `Coderynx.MessagingKit.Transports.InMemory` to enable version tracking for this package.
* Bumped the version in `Coderynx.MessagingKit/version.json` from `0.0.1` to `0.0.2` to reflect new changes.

**Dependency management:**

* In `Coderynx.MessagingKit.csproj`, replaced the project reference to `Coderynx.MessagingKit.Abstractions` with a package reference, streamlining the dependency and aligning with package-based versioning.