### PR TITLE
Add `Coderynx.MessagingKit` to transport packages

### DIFF
--- a/src/Coderynx.MessagingKit.Transports.InMemory/Coderynx.MessagingKit.Transports.InMemory.csproj
+++ b/src/Coderynx.MessagingKit.Transports.InMemory/Coderynx.MessagingKit.Transports.InMemory.csproj
@@ -19,7 +19,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\Coderynx.MessagingKit\Coderynx.MessagingKit.csproj"/>
+      <PackageReference Include="Coderynx.MessagingKit" Version="0.0.2" />
     </ItemGroup>
 
 </Project>

--- a/src/Coderynx.MessagingKit.Transports.InMemory/version.json
+++ b/src/Coderynx.MessagingKit.Transports.InMemory/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "publicReleaseRefSpec": [
     "^refs/heads/main$"
   ],

--- a/src/Coderynx.MessagingKit.Transports.RabbitMq/Coderynx.MessagingKit.Transports.RabbitMq.csproj
+++ b/src/Coderynx.MessagingKit.Transports.RabbitMq/Coderynx.MessagingKit.Transports.RabbitMq.csproj
@@ -19,10 +19,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\Coderynx.MessagingKit\Coderynx.MessagingKit.csproj"/>
-    </ItemGroup>
-
-    <ItemGroup>
+        <PackageReference Include="Coderynx.MessagingKit" Version="0.0.2" />
         <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.9"/>
         <PackageReference Include="RabbitMQ.Client" Version="7.1.2"/>
     </ItemGroup>

--- a/src/Coderynx.MessagingKit.Transports.RabbitMq/version.json
+++ b/src/Coderynx.MessagingKit.Transports.RabbitMq/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "publicReleaseRefSpec": [
     "^refs/heads/main$"
   ],


### PR DESCRIPTION
This pull request updates the transport projects to depend on the released NuGet package version of `Coderynx.MessagingKit` instead of referencing the local project, and bumps the version numbers for both transport projects to `0.0.2`.

Dependency management:

* Replaced `ProjectReference` to the local `Coderynx.MessagingKit` project with a `PackageReference` to the published `Coderynx.MessagingKit` NuGet package version `0.0.2` in both `Coderynx.MessagingKit.Transports.InMemory.csproj` and `Coderynx.MessagingKit.Transports.RabbitMq.csproj`. [[1]](diffhunk://#diff-2f2b398aa881e105b6930e1b70d74aa7c30f182240fb7fd704c02abee3916dc4L22-R22) [[2]](diffhunk://#diff-965f2f9eb43034870b8b4e4abec85726ed2d4227cd20713cc618d73e73ef5fcbL22-R22)

Versioning:

* Updated the `version.json` files for both `Coderynx.MessagingKit.Transports.InMemory` and `Coderynx.MessagingKit.Transports.RabbitMq` to set the version to `0.0.2`.