### PR TITLE
Code cleanup and README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# Coderynx.MessagingKit
+# MessagingKit
 
-This repository contains the core messaging abstractions and transports (RabbitMQ, InMemory) for Coderynx.MessagingKit.
+A .NET library for building distributed application with support for multiple messaging backends.

--- a/src/Coderynx.MessagingKit.Transports.InMemory/Coderynx.MessagingKit.Transports.InMemory.csproj
+++ b/src/Coderynx.MessagingKit.Transports.InMemory/Coderynx.MessagingKit.Transports.InMemory.csproj
@@ -19,7 +19,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Coderynx.MessagingKit" Version="0.0.2" />
+        <PackageReference Include="Coderynx.MessagingKit" Version="0.0.2"/>
     </ItemGroup>
 
 </Project>

--- a/src/Coderynx.MessagingKit.Transports.InMemory/InMemoryOptions.cs
+++ b/src/Coderynx.MessagingKit.Transports.InMemory/InMemoryOptions.cs
@@ -2,7 +2,5 @@ using Coderynx.MessagingKit.Abstractions;
 
 namespace Coderynx.MessagingKit.Transports.InMemory;
 
-public sealed record InMemoryOptions(
-    string BusName,
-    HashSet<MessageRegistration> MessageRegistrations)
+public sealed record InMemoryOptions(string BusName, HashSet<MessageRegistration> MessageRegistrations)
     : MessageBusOptionsBase(typeof(InMemoryMessageBus), BusName, MessageRegistrations);

--- a/src/Coderynx.MessagingKit.Transports.RabbitMq/Coderynx.MessagingKit.Transports.RabbitMq.csproj
+++ b/src/Coderynx.MessagingKit.Transports.RabbitMq/Coderynx.MessagingKit.Transports.RabbitMq.csproj
@@ -19,7 +19,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Coderynx.MessagingKit" Version="0.0.2" />
+        <PackageReference Include="Coderynx.MessagingKit" Version="0.0.2"/>
         <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.9"/>
         <PackageReference Include="RabbitMQ.Client" Version="7.1.2"/>
     </ItemGroup>

--- a/src/Coderynx.MessagingKit/Coderynx.MessagingKit.csproj
+++ b/src/Coderynx.MessagingKit/Coderynx.MessagingKit.csproj
@@ -19,7 +19,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Coderynx.MessagingKit.Abstractions" Version="0.0.1" />
+        <PackageReference Include="Coderynx.MessagingKit.Abstractions" Version="0.0.1"/>
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.9"/>
         <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.9"/>
         <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.9"/>


### PR DESCRIPTION
This pull request focuses on minor code style and documentation improvements to the `MessagingKit` project, particularly in the in-memory transport and the README. These changes do not affect functionality but improve code readability and project clarity.

**Documentation improvements:**
- Updated the `README.md` to clarify the library's purpose and generalize its description, making it more accessible to new users.

**Code style and readability enhancements (In-Memory Transport):**
- Refactored channel creation in `InMemoryMessageBus` to use a named `UnboundedChannelOptions` variable, improving clarity.
- Reformatted the topic name generation logic in `PublishAsync` for better readability and maintainability.
- Changed a comment in the `DisposeAsync` method from a C-style comment to a standard C# single-line comment for consistency.
- Reformatted the `InMemoryOptions` record declaration to a single line for improved code style.