### PR TITLE
Bump transport packages version to 0.0.3

### DIFF
--- a/src/Coderynx.MessagingKit.Transports.InMemory/Coderynx.MessagingKit.Transports.InMemory.csproj
+++ b/src/Coderynx.MessagingKit.Transports.InMemory/Coderynx.MessagingKit.Transports.InMemory.csproj
@@ -19,7 +19,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Coderynx.MessagingKit" Version="0.0.2"/>
+        <PackageReference Include="Coderynx.MessagingKit" Version="0.0.3" />
     </ItemGroup>
 
 </Project>

--- a/src/Coderynx.MessagingKit.Transports.InMemory/version.json
+++ b/src/Coderynx.MessagingKit.Transports.InMemory/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "publicReleaseRefSpec": [
     "^refs/heads/main$"
   ],

--- a/src/Coderynx.MessagingKit.Transports.RabbitMq/Coderynx.MessagingKit.Transports.RabbitMq.csproj
+++ b/src/Coderynx.MessagingKit.Transports.RabbitMq/Coderynx.MessagingKit.Transports.RabbitMq.csproj
@@ -19,7 +19,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Coderynx.MessagingKit" Version="0.0.2"/>
+        <PackageReference Include="Coderynx.MessagingKit" Version="0.0.3" />
         <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.9"/>
         <PackageReference Include="RabbitMQ.Client" Version="7.1.2"/>
     </ItemGroup>

--- a/src/Coderynx.MessagingKit.Transports.RabbitMq/version.json
+++ b/src/Coderynx.MessagingKit.Transports.RabbitMq/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "publicReleaseRefSpec": [
     "^refs/heads/main$"
   ],


### PR DESCRIPTION
This pull request updates the `Coderynx.MessagingKit.Transports.InMemory` and `Coderynx.MessagingKit.Transports.RabbitMq` packages to reference the latest version of `Coderynx.MessagingKit` and increments their own package versions accordingly.

Dependency updates:

* Updated the `Coderynx.MessagingKit` package reference from version `0.0.2` to `0.0.3` in both `Coderynx.MessagingKit.Transports.InMemory.csproj` and `Coderynx.MessagingKit.Transports.RabbitMq.csproj` to ensure compatibility with the latest features and fixes. [[1]](diffhunk://#diff-2f2b398aa881e105b6930e1b70d74aa7c30f182240fb7fd704c02abee3916dc4L22-R22) [[2]](diffhunk://#diff-965f2f9eb43034870b8b4e4abec85726ed2d4227cd20713cc618d73e73ef5fcbL22-R22)

Versioning:

* Bumped the package version from `0.0.2` to `0.0.3` in the `version.json` files for both transports to reflect the dependency update.