### PR TITLE
Upgrade to .NET 10 and update dependencies and workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 9.x
+          dotnet-version: 10.x
 
       - name: Restore dependencies
         run: dotnet restore

--- a/.github/workflows/release-nuget-package.yml
+++ b/.github/workflows/release-nuget-package.yml
@@ -15,7 +15,7 @@ on:
         description: '.NET version to use'
         required: false
         type: string
-        default: '9.x'
+        default: '10.x'
     secrets:
       NUGET_API_KEY:
         required: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     with:
       project-path: ${{ matrix.project-path }}
       project-name: ${{ matrix.project-name }}
-      dotnet-version: '9.x'
+      dotnet-version: '10.x'
     secrets:
       NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
     strategy:

--- a/src/Coderynx.MessagingKit.Abstractions/Coderynx.MessagingKit.Abstractions.csproj
+++ b/src/Coderynx.MessagingKit.Abstractions/Coderynx.MessagingKit.Abstractions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <PackageId>Coderynx.MessagingKit.Abstractions</PackageId>
@@ -16,6 +16,12 @@
 
     <ItemGroup>
         <None Include="..\..\README.md" Pack="true" PackagePath=""/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Update="Nerdbank.GitVersioning">
+            <Version>3.9.50</Version>
+        </PackageReference>
     </ItemGroup>
 
 </Project>

--- a/src/Coderynx.MessagingKit.Abstractions/version.json
+++ b/src/Coderynx.MessagingKit.Abstractions/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "publicReleaseRefSpec": [
     "^refs/heads/main$"
   ],

--- a/src/Coderynx.MessagingKit.Transports.InMemory/Coderynx.MessagingKit.Transports.InMemory.csproj
+++ b/src/Coderynx.MessagingKit.Transports.InMemory/Coderynx.MessagingKit.Transports.InMemory.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <PackageId>Coderynx.MessagingKit.Transports.InMemory</PackageId>
@@ -19,7 +19,10 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Coderynx.MessagingKit" Version="0.0.3" />
+        <PackageReference Include="Coderynx.MessagingKit" Version="0.0.3"/>
+        <PackageReference Update="Nerdbank.GitVersioning">
+            <Version>3.9.50</Version>
+        </PackageReference>
     </ItemGroup>
 
 </Project>

--- a/src/Coderynx.MessagingKit.Transports.InMemory/InMemoryMessageBus.cs
+++ b/src/Coderynx.MessagingKit.Transports.InMemory/InMemoryMessageBus.cs
@@ -69,7 +69,7 @@ internal sealed class InMemoryMessageBus(
         }
 
         await channel.Writer.WriteAsync(letter, cancellationToken);
-        
+
         logger.LogDebug("Published message on topic {Topic} using InMemory bus", topic);
     }
 

--- a/src/Coderynx.MessagingKit.Transports.RabbitMq/Coderynx.MessagingKit.Transports.RabbitMq.csproj
+++ b/src/Coderynx.MessagingKit.Transports.RabbitMq/Coderynx.MessagingKit.Transports.RabbitMq.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <PackageId>Coderynx.MessagingKit.Transports.RabbitMq</PackageId>
@@ -19,9 +19,12 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Coderynx.MessagingKit" Version="0.0.3" />
-        <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.9"/>
-        <PackageReference Include="RabbitMQ.Client" Version="7.1.2"/>
+        <PackageReference Include="Coderynx.MessagingKit" Version="0.0.3"/>
+        <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.5"/>
+        <PackageReference Include="RabbitMQ.Client" Version="7.2.1"/>
+        <PackageReference Update="Nerdbank.GitVersioning">
+            <Version>3.9.50</Version>
+        </PackageReference>
     </ItemGroup>
 
 </Project>

--- a/src/Coderynx.MessagingKit/Coderynx.MessagingKit.csproj
+++ b/src/Coderynx.MessagingKit/Coderynx.MessagingKit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <PackageId>Coderynx.MessagingKit</PackageId>
@@ -20,9 +20,12 @@
 
     <ItemGroup>
         <PackageReference Include="Coderynx.MessagingKit.Abstractions" Version="0.0.1"/>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.9"/>
-        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.9"/>
-        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.9"/>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5"/>
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.5"/>
+        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.5"/>
+        <PackageReference Update="Nerdbank.GitVersioning">
+            <Version>3.9.50</Version>
+        </PackageReference>
     </ItemGroup>
 
 </Project>

--- a/src/Coderynx.MessagingKit/DependencyInjection.cs
+++ b/src/Coderynx.MessagingKit/DependencyInjection.cs
@@ -1,6 +1,5 @@
 using Coderynx.MessagingKit.Abstractions;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 
 namespace Coderynx.MessagingKit;
 

--- a/tests/Coderynx.MessagingKit.Tests.Shared/Coderynx.MessagingKit.Tests.Shared.csproj
+++ b/tests/Coderynx.MessagingKit.Tests.Shared/Coderynx.MessagingKit.Tests.Shared.csproj
@@ -1,13 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>
 
     <ItemGroup>
         <ProjectReference Include="..\..\src\Coderynx.MessagingKit\Coderynx.MessagingKit.csproj"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Update="Nerdbank.GitVersioning">
+            <Version>3.9.50</Version>
+        </PackageReference>
     </ItemGroup>
 
 </Project>

--- a/tests/Coderynx.MessagingKit.Transports.InMemory.IntegrationTests/Coderynx.MessagingKit.Transports.InMemory.IntegrationTests.csproj
+++ b/tests/Coderynx.MessagingKit.Transports.InMemory.IntegrationTests/Coderynx.MessagingKit.Transports.InMemory.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
@@ -9,12 +9,21 @@
 
     <ItemGroup>
         <PackageReference Include="AutoFixture" Version="4.18.1"/>
-        <PackageReference Include="coverlet.collector" Version="6.0.2"/>
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.9"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0"/>
+        <PackageReference Include="coverlet.collector" Version="8.0.1">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.5"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0"/>
         <PackageReference Include="Shouldly" Version="4.3.0"/>
-        <PackageReference Include="xunit" Version="2.9.2"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2"/>
+        <PackageReference Include="xunit" Version="2.9.3"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Update="Nerdbank.GitVersioning">
+            <Version>3.9.50</Version>
+        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/Coderynx.MessagingKit.Transports.RabbitMq.IntegrationTests/ApplicationFactory.cs
+++ b/tests/Coderynx.MessagingKit.Transports.RabbitMq.IntegrationTests/ApplicationFactory.cs
@@ -13,8 +13,8 @@ namespace Coderynx.MessagingKit.Transports.RabbitMq.IntegrationTests;
 
 public sealed class ApplicationFactory : WebApplicationFactory<ApplicationFactory>, IAsyncLifetime
 {
-    private readonly RabbitMqContainer _rabbitMqContainer = new Testcontainers.RabbitMq.RabbitMqBuilder()
-        .Build();
+    private readonly RabbitMqContainer _rabbitMqContainer =
+        new Testcontainers.RabbitMq.RabbitMqBuilder("rabbitmq:latest").Build();
 
     public async Task InitializeAsync()
     {

--- a/tests/Coderynx.MessagingKit.Transports.RabbitMq.IntegrationTests/Coderynx.MessagingKit.Transports.RabbitMq.IntegrationTests.csproj
+++ b/tests/Coderynx.MessagingKit.Transports.RabbitMq.IntegrationTests/Coderynx.MessagingKit.Transports.RabbitMq.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
@@ -10,21 +10,21 @@
 
     <ItemGroup>
         <PackageReference Include="AutoFixture" Version="4.18.1"/>
-        <PackageReference Include="coverlet.collector" Version="6.0.2">
+        <PackageReference Include="coverlet.collector" Version="8.0.1">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.9"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0"/>
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.5"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0"/>
         <PackageReference Include="Shouldly" Version="4.3.0"/>
         <PackageReference Include="xunit" Version="2.9.3"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Testcontainers.RabbitMq" Version="4.7.0"/>
+        <PackageReference Include="Testcontainers.RabbitMq" Version="4.11.0"/>
         <PackageReference Update="Nerdbank.GitVersioning">
-            <Version>3.8.118</Version>
+            <Version>3.9.50</Version>
         </PackageReference>
     </ItemGroup>
 


### PR DESCRIPTION
This pull request upgrades the entire solution from .NET 9 to .NET 10, updates related dependencies to their latest compatible versions, and standardizes versioning across all projects using Nerdbank.GitVersioning. It also updates CI/CD workflows to use .NET 10 and refreshes several test and runtime dependencies for better compatibility and features.

**.NET 10 Migration and Dependency Upgrades**

* Migrated all projects (`Coderynx.MessagingKit`, `Abstractions`, `Transports.InMemory`, `Transports.RabbitMq`, and all test projects) from `net9.0` to `net10.0` target framework. [[1]](diffhunk://#diff-86bca5ea3d60c40665ebedc6f54b34664ca7af74db0f0d09830986baac806643L4-R4) [[2]](diffhunk://#diff-2f2b398aa881e105b6930e1b70d74aa7c30f182240fb7fd704c02abee3916dc4L4-R4) [[3]](diffhunk://#diff-965f2f9eb43034870b8b4e4abec85726ed2d4227cd20713cc618d73e73ef5fcbL4-R4) [[4]](diffhunk://#diff-513013283634fbe201257cf4d3dd10deaad5cccd3bae0e1195cf5eef8836920dL4-R4) [[5]](diffhunk://#diff-f51c2e006048995c31009b268c7815a140012fb507abf88b914a0daa79c7d1f7L4-R4) [[6]](diffhunk://#diff-7e613929cdb0d7633a87f0c0c660d4a48183146293b8b21245f9c3d276e7d2e1L4-R26) [[7]](diffhunk://#diff-84d18e8a4ecc911da8f2ecf9be036b916c656bf920f2af5b609c2fd027d66d58L4-R4)
* Updated key dependencies to their latest major versions compatible with .NET 10, including:
  - `Microsoft.Extensions.*` packages to `10.0.5`
  - `RabbitMQ.Client` to `7.2.1`
  - `coverlet.collector` to `8.0.1`
  - `Microsoft.AspNetCore.Mvc.Testing` to `10.0.5`
  - `Microsoft.NET.Test.Sdk` to `18.3.0`
  - `Testcontainers.RabbitMq` to `4.11.0`
  - `xunit.runner.visualstudio` to `3.1.5` [[1]](diffhunk://#diff-965f2f9eb43034870b8b4e4abec85726ed2d4227cd20713cc618d73e73ef5fcbL23-R27) [[2]](diffhunk://#diff-513013283634fbe201257cf4d3dd10deaad5cccd3bae0e1195cf5eef8836920dL23-R28) [[3]](diffhunk://#diff-7e613929cdb0d7633a87f0c0c660d4a48183146293b8b21245f9c3d276e7d2e1L4-R26) [[4]](diffhunk://#diff-84d18e8a4ecc911da8f2ecf9be036b916c656bf920f2af5b609c2fd027d66d58L13-R27)

**Build, Versioning, and CI/CD Improvements**

* Added or updated `Nerdbank.GitVersioning` (version `3.9.50`) as a package reference to all projects for consistent versioning. [[1]](diffhunk://#diff-86bca5ea3d60c40665ebedc6f54b34664ca7af74db0f0d09830986baac806643R21-R26) [[2]](diffhunk://#diff-2f2b398aa881e105b6930e1b70d74aa7c30f182240fb7fd704c02abee3916dc4R23-R25) [[3]](diffhunk://#diff-965f2f9eb43034870b8b4e4abec85726ed2d4227cd20713cc618d73e73ef5fcbL23-R27) [[4]](diffhunk://#diff-513013283634fbe201257cf4d3dd10deaad5cccd3bae0e1195cf5eef8836920dL23-R28) [[5]](diffhunk://#diff-f51c2e006048995c31009b268c7815a140012fb507abf88b914a0daa79c7d1f7R13-R18) [[6]](diffhunk://#diff-7e613929cdb0d7633a87f0c0c660d4a48183146293b8b21245f9c3d276e7d2e1L4-R26) [[7]](diffhunk://#diff-84d18e8a4ecc911da8f2ecf9be036b916c656bf920f2af5b609c2fd027d66d58L13-R27)
* Updated `version.json` to increment the base version from `0.0.1` to `0.0.2`.
* Updated GitHub Actions workflows (`ci.yml`, `release.yml`, `release-nuget-package.yml`) to use .NET 10 instead of 9. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL26-R26) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L19-R19) [[3]](diffhunk://#diff-b5a4144419e741154b1c4fef5463956dd42c5e0f51cc5989234900bd1f372d61L18-R18)

**Testing and Containerization**

* Updated test dependencies and configurations to align with .NET 10 and latest test frameworks. [[1]](diffhunk://#diff-7e613929cdb0d7633a87f0c0c660d4a48183146293b8b21245f9c3d276e7d2e1L4-R26) [[2]](diffhunk://#diff-84d18e8a4ecc911da8f2ecf9be036b916c656bf920f2af5b609c2fd027d66d58L13-R27)
* Modified the RabbitMQ test container initialization to explicitly use the `rabbitmq:latest` image tag for consistency.

**Minor Codebase Cleanup**

* Removed an unused `using Microsoft.Extensions.Hosting;` directive from `DependencyInjection.cs`.

These changes ensure the codebase is up-to-date with the latest .NET ecosystem, improves maintainability, and prepares the projects for future enhancements.