### PR TITLE
Bump MessagingKit.Abstractions and version.json to latest versions

### DIFF
--- a/src/Coderynx.MessagingKit/Coderynx.MessagingKit.csproj
+++ b/src/Coderynx.MessagingKit/Coderynx.MessagingKit.csproj
@@ -19,7 +19,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Coderynx.MessagingKit.Abstractions" Version="0.0.1"/>
+        <PackageReference Include="Coderynx.MessagingKit.Abstractions" Version="0.0.2"/>
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5"/>
         <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.5"/>
         <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.5"/>

--- a/src/Coderynx.MessagingKit/version.json
+++ b/src/Coderynx.MessagingKit/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "publicReleaseRefSpec": [
     "^refs/heads/main$"
   ],


### PR DESCRIPTION
This pull request makes a minor update to the `Coderynx.MessagingKit` library, primarily updating package dependencies and incrementing the project version.

Dependency update:

* Upgraded the `Coderynx.MessagingKit.Abstractions` package dependency from version `0.0.1` to `0.0.2` in the project file (`Coderynx.MessagingKit.csproj`).

Versioning:

* Bumped the library version from `0.0.3` to `0.0.4` in `version.json` to reflect the new changes.