### PR TITLE
Bump MessagingKit transports to version 0.0.4

### DIFF
--- a/src/Coderynx.MessagingKit.Transports.InMemory/Coderynx.MessagingKit.Transports.InMemory.csproj
+++ b/src/Coderynx.MessagingKit.Transports.InMemory/Coderynx.MessagingKit.Transports.InMemory.csproj
@@ -19,7 +19,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Coderynx.MessagingKit" Version="0.0.3"/>
+        <PackageReference Include="Coderynx.MessagingKit" Version="0.0.4"/>
         <PackageReference Update="Nerdbank.GitVersioning">
             <Version>3.9.50</Version>
         </PackageReference>

--- a/src/Coderynx.MessagingKit.Transports.InMemory/version.json
+++ b/src/Coderynx.MessagingKit.Transports.InMemory/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "publicReleaseRefSpec": [
     "^refs/heads/main$"
   ],

--- a/src/Coderynx.MessagingKit.Transports.RabbitMq/Coderynx.MessagingKit.Transports.RabbitMq.csproj
+++ b/src/Coderynx.MessagingKit.Transports.RabbitMq/Coderynx.MessagingKit.Transports.RabbitMq.csproj
@@ -19,7 +19,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Coderynx.MessagingKit" Version="0.0.3"/>
+        <PackageReference Include="Coderynx.MessagingKit" Version="0.0.4"/>
         <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.5"/>
         <PackageReference Include="RabbitMQ.Client" Version="7.2.1"/>
         <PackageReference Update="Nerdbank.GitVersioning">

--- a/src/Coderynx.MessagingKit.Transports.RabbitMq/version.json
+++ b/src/Coderynx.MessagingKit.Transports.RabbitMq/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "publicReleaseRefSpec": [
     "^refs/heads/main$"
   ],


### PR DESCRIPTION
This pull request updates both the InMemory and RabbitMq transport projects to use version 0.0.4 of the `Coderynx.MessagingKit` package and increments their own version numbers to 0.0.4 for release alignment.

Dependency updates:

* Updated the `Coderynx.MessagingKit` package reference from version 0.0.3 to 0.0.4 in both `Coderynx.MessagingKit.Transports.InMemory.csproj` and `Coderynx.MessagingKit.Transports.RabbitMq.csproj`. [[1]](diffhunk://#diff-2f2b398aa881e105b6930e1b70d74aa7c30f182240fb7fd704c02abee3916dc4L22-R22) [[2]](diffhunk://#diff-965f2f9eb43034870b8b4e4abec85726ed2d4227cd20713cc618d73e73ef5fcbL22-R22)

Versioning:

* Bumped the version in `version.json` from 0.0.3 to 0.0.4 for both the InMemory and RabbitMq transport projects to match the new dependency version.